### PR TITLE
Fixed bulk insert close bug

### DIFF
--- a/PSSQLite/Invoke-SqliteBulkCopy.ps1
+++ b/PSSQLite/Invoke-SqliteBulkCopy.ps1
@@ -149,7 +149,7 @@
         [cmdletbinding()]
         param($conn, $com, $BoundParams)
         #Only dispose of the connection if we created it
-        if($BoundParams.Keys -notcontains 'SQLConnection')
+        if($BoundParams.Keys -notcontains 'SQLiteConnection')
         {
             $conn.Close()
             $conn.Dispose()


### PR DESCRIPTION
In the CleanUp function there was a bug where we check for BoundParams
to make sure that it does not contain a key 'SQLConnection'.  If it
doesn't contain such a key then we close and cleanup.  The actual key
that gets passed for this to work is SQLiteConnection so made a slight
edit to change this and tested and the connection stays open after a
bulk insert where SQLiteConnection is passed as a parameter.