### PR TITLE
Forced $Columns as an array no line 264 to prevent an error condition…

### DIFF
--- a/PSSQLite/Invoke-SqliteBulkCopy.ps1
+++ b/PSSQLite/Invoke-SqliteBulkCopy.ps1
@@ -261,7 +261,7 @@
     if ($Force -or $PSCmdlet.ShouldProcess("$($DataTable.Rows.Count) rows, with BoundParameters $($PSBoundParameters | Out-String)", "SQL Bulk Copy"))
     {
         #Get column info...
-            $Columns = $DataTable.Columns | Select -ExpandProperty ColumnName
+            [array]$Columns = $DataTable.Columns | Select-Object -ExpandProperty ColumnName
             $ColumnTypeHash = @{}
             $ColumnToParamHash = @{}
             $Index = 0


### PR DESCRIPTION
… on line 313 since PowerShell turns it in as a string if there is only a single column in the data table.

If there is only one column an error is thrown during bulk inserts:

```
Index operation failed; the array index evaluated to null.
At C:\repo\PSSQLite\PSSQLite\Invoke-SqliteBulkCopy.ps1:342 char:29
+ ...             $Command.Parameters[$ColumnToParamHash[$Columns[$col]]].V ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : NullArrayIndex
 
Rolled back due to error:
Exception calling "ExecuteNonQuery" with "0" argument(s): "constraint failed
NOT NULL constraint failed: test_table.names"
At C:\repo\PSSQLite\PSSQLite\Invoke-SqliteBulkCopy.ps1:360 char:29
+                             Throw "Rolled back due to error:`n$_"
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Rolled back due...st_table.names":String) [], RuntimeException
    + FullyQualifiedErrorId : Rolled back due to error:
Exception calling "ExecuteNonQuery" with "0" argument(s): "constraint failed
NOT NULL constraint failed: test_table.names"
```

I reproduced this with the current master with the lines below.  The bulk import will fail unless we force columns to be an array.

```PowerShell
Import-Module C:\repo\PSSQLite\PSSQLite -Force
$dbPath = 'c:\temp\test.db'
$createSplat = @{
    DataSource = $dbPath
    Query = 'CREATE TABLE test_table (names TEXT NOT NULL)'
}
Invoke-SqliteQuery @createSplat

$names = @(
'steve'
'tom'
'john'
)

$array = $names | ForEach-Object { [PSCustomObject]@{names=$_} }
$dt = $array | Out-DataTable

$bulkSplat = @{
    ConflictClause = 'Replace'
    DataSource = $dbPath
    DataTable = $dt
    Force = $true
    Table = 'test_table'
}
Invoke-SQLiteBulkCopy @bulkSplat

Invoke-SqliteQuery -DataSource $dbPath -Query 'select * from test_table'

Remove-Item $dbPath
```