### PR TITLE
Use ParseViaFramework constructor parameter rather than via property

### DIFF
--- a/PSSQLite/Invoke-SqliteQuery.ps1
+++ b/PSSQLite/Invoke-SqliteQuery.ps1
@@ -408,8 +408,7 @@
 
                 $ConnectionString = "Data Source={0}" -f $Database
 
-                $conn = New-Object System.Data.SQLite.SQLiteConnection -ArgumentList $ConnectionString
-                $conn.ParseViaFramework = $true #Allow UNC paths, thanks to Ray Alex!
+                $conn = New-Object System.Data.SQLite.SQLiteConnection -ArgumentList $ConnectionString,$true #Allow UNC paths, thanks to Ray Alex!
                 Write-Debug "ConnectionString $ConnectionString"
 
                 Try

--- a/PSSQLite/New-SqliteConnection.ps1
+++ b/PSSQLite/New-SqliteConnection.ps1
@@ -116,8 +116,7 @@
                 $ConnectionString += "Read Only=True;"
             }
         
-            $conn = New-Object System.Data.SQLite.SQLiteConnection -ArgumentList $ConnectionString
-            $conn.ParseViaFramework = $true #Allow UNC paths, thanks to Ray Alex!
+            $conn = New-Object System.Data.SQLite.SQLiteConnection -ArgumentList $ConnectionString,$true
             Write-Debug "ConnectionString $ConnectionString"
 
             if($Open)

--- a/PSSQLite/New-SqliteConnection.ps1
+++ b/PSSQLite/New-SqliteConnection.ps1
@@ -116,7 +116,7 @@
                 $ConnectionString += "Read Only=True;"
             }
         
-            $conn = New-Object System.Data.SQLite.SQLiteConnection -ArgumentList $ConnectionString,$true
+            $conn = New-Object System.Data.SQLite.SQLiteConnection -ArgumentList $ConnectionString,$true #Allow UNC paths, thanks to Ray Alex!
             Write-Debug "ConnectionString $ConnectionString"
 
             if($Open)

--- a/Tests/Invoke-SQLiteQuery.Tests.ps1
+++ b/Tests/Invoke-SQLiteQuery.Tests.ps1
@@ -52,13 +52,13 @@ Describe "Invoke-SQLiteQuery PS$PSVersion" {
         It 'should support parameterized queries' {
             
             $Out = @( Invoke-SQLiteQuery @Verbose -Database $SQLiteFile -Query "SELECT * FROM NAMES WHERE BirthDate >= @Date" -SqlParameters @{
-                Date = (Get-Date 3/13/2012)
+                Date = (Get-Date -Year 2012 -Month 3 -Day 13)
             } -ErrorAction Stop )
             $Out.count | Should Be 1
             $Out[0].fullname | Should Be "Cookie Monster"
 
             $Out = @( Invoke-SQLiteQuery @Verbose -Database $SQLiteFile -Query "SELECT * FROM NAMES WHERE BirthDate >= @Date" -SqlParameters @{
-                Date = (Get-Date 3/15/2012)
+                Date = (Get-Date -Year 2012 -Month 3 -Day 15)
             } -ErrorAction Stop )
             $Out.count | Should Be 0
         }


### PR DESCRIPTION
When using this module, I got an error about the property "ParseViaFramework". When reviewing documentation, I found that there is also a constructor parameter for the same property in SQLiteConnection, this does not throw an error on my machine. I was still able to open a database on a UNC path (starting with \\servername), so I think this does not introduce a regression. 

Additionally, the test failed on my end because I don't use the American date format, so I made that test slightly more robust as well. 