### PR TITLE
Fixed to pass script analyzer tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Working.SQLite

--- a/PSSQLite/Invoke-SqliteBulkCopy.ps1
+++ b/PSSQLite/Invoke-SqliteBulkCopy.ps1
@@ -135,11 +135,7 @@
         $NotifyAfter = 0,
 
         [switch]
-        $Force,
-
-        [Int32]
-        $QueryTimeout = 600
-
+        $Force
     )
 
     Write-Verbose "Running Invoke-SQLiteBulkCopy with ParameterSet '$($PSCmdlet.ParameterSetName)'."
@@ -246,7 +242,6 @@
                 $SQLiteConnection.Open()
             }
             $Command = $SQLiteConnection.CreateCommand()
-            $CommandTimeout = $QueryTimeout
             $Transaction = $SQLiteConnection.BeginTransaction()
         }
         Catch

--- a/PSSQLite/Invoke-SqliteBulkCopy.ps1
+++ b/PSSQLite/Invoke-SqliteBulkCopy.ps1
@@ -189,7 +189,7 @@
         }
     }
 
-    function New-SqliteBulkQuery {
+    function Invoke-SqliteBulkQuery {
         [CmdletBinding()]
         Param(
             [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
@@ -303,11 +303,11 @@
         #Build up the query
             if ($PSBoundParameters.ContainsKey('ConflictClause'))
             {
-                $Command.CommandText = New-SqliteBulkQuery -Table $Table -Columns $ColumnToParamHash.Keys -Parameters $ColumnToParamHash.Values -ConflictClause $ConflictClause
+                $Command.CommandText = Invoke-SqliteBulkQuery -Table $Table -Columns $ColumnToParamHash.Keys -Parameters $ColumnToParamHash.Values -ConflictClause $ConflictClause
             }
             else
             {
-                $Command.CommandText = New-SqliteBulkQuery -Table $Table -Columns $ColumnToParamHash.Keys -Parameters $ColumnToParamHash.Values
+                $Command.CommandText = Invoke-SqliteBulkQuery -Table $Table -Columns $ColumnToParamHash.Keys -Parameters $ColumnToParamHash.Values
             }
 
             foreach ($Column in $Columns)

--- a/PSSQLite/Invoke-SqliteQuery.ps1
+++ b/PSSQLite/Invoke-SqliteQuery.ps1
@@ -290,7 +290,7 @@
             }
             Catch
             {
-                if( -not ($Library = Add-Type -path $SQLiteAssembly -PassThru -ErrorAction stop) )
+                if( -not (Add-Type -path $SQLiteAssembly -PassThru -ErrorAction stop) )
                 {
                     Throw "This module requires the ADO.NET driver for SQLite:`n`thttp://system.data.sqlite.org/index.html/doc/trunk/www/downloads.wiki"
                 }
@@ -427,11 +427,11 @@
             $cmd.CommandText = $Query
             $cmd.CommandTimeout = $QueryTimeout
 
-            if ($SqlParameters -ne $null)
+            if ($null -ne $SqlParameters)
             {
                 $SqlParameters.GetEnumerator() |
                     ForEach-Object {
-                        If ($_.Value -ne $null)
+                        If ($null -ne $_.Value)
                         {
                             if($_.Value -is [datetime]) { $_.Value = $_.Value.ToString("yyyy-MM-dd HH:mm:ss") }
                             $cmd.Parameters.AddWithValue("@$($_.Key)", $_.Value)

--- a/PSSQLite/New-SqliteConnection.ps1
+++ b/PSSQLite/New-SqliteConnection.ps1
@@ -55,7 +55,7 @@
         SQL
 
     #>
-    [cmdletbinding(SupportsShouldProcess)]
+    [cmdletbinding(SupportsShouldProcess=$false)]
     [OutputType([System.Data.SQLite.SQLiteConnection])]
     param(
         [Parameter( Position=0,

--- a/PSSQLite/New-SqliteConnection.ps1
+++ b/PSSQLite/New-SqliteConnection.ps1
@@ -55,7 +55,7 @@
         SQL
 
     #>
-    [cmdletbinding(SupportsShouldProcess=$false)]
+    [cmdletbinding(SupportsShouldProcess)]
     [OutputType([System.Data.SQLite.SQLiteConnection])]
     param(
         [Parameter( Position=0,

--- a/PSSQLite/New-SqliteConnection.ps1
+++ b/PSSQLite/New-SqliteConnection.ps1
@@ -55,7 +55,7 @@
         SQL
 
     #>
-    [cmdletbinding(SupportsShouldProcess)]
+    [cmdletbinding(SupportsShouldProcess=$true)]
     [OutputType([System.Data.SQLite.SQLiteConnection])]
     param(
         [Parameter( Position=0,

--- a/PSSQLite/Out-DataTable.ps1
+++ b/PSSQLite/Out-DataTable.ps1
@@ -121,7 +121,7 @@
                     $Col.ColumnName = $Name  
                     
                     #If it's not DBNull or Null, get the type
-                    if ($Value -isnot [System.DBNull] -and $Value -ne $null)
+                    if ($Value -isnot [System.DBNull] -and $null -ne $Value)
                     {
                         $Col.DataType = [System.Type]::GetType( $(Get-ODTType $property.TypeNameOfValue) )
                     }
@@ -149,7 +149,7 @@
                     {
                         $DR.Item($Name) = $Value | ConvertTo-XML -As String -NoTypeInformation -Depth 1
                     }
-                    elseif($Value -eq $null)
+                    elseif($null -eq $Value)
                     {
                         $DR.Item($Name) = [DBNull]::Value
                     }
@@ -165,7 +165,7 @@
                 }
 
                 #Did we get a null or dbnull for a non-nullable item?  let the user know.
-                if($NonNullable -contains $Name -and ($Value -is [System.DBNull] -or $Value -eq $null))
+                if($NonNullable -contains $Name -and ($Value -is [System.DBNull] -or $null -eq $Value))
                 {
                     write-verbose "NonNullable property '$Name' with null value found: $($object | out-string)"
                 }

--- a/PSSQLite/PSSQLite.psm1
+++ b/PSSQLite/PSSQLite.psm1
@@ -1,4 +1,5 @@
-﻿#handle PS2
+﻿
+#handle PS2
     if(-not $PSScriptRoot)
     {
         $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent

--- a/PSSQLite/PSSQLite.psm1
+++ b/PSSQLite/PSSQLite.psm1
@@ -1,5 +1,4 @@
-﻿
-#handle PS2
+﻿#handle PS2
     if(-not $PSScriptRoot)
     {
         $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent

--- a/PSSQLite/PSSQLite.psm1
+++ b/PSSQLite/PSSQLite.psm1
@@ -18,7 +18,7 @@
         Throw "Something is odd with bitness..."
     }
 
-    if( -not ($Library = Add-Type -path $SQLiteAssembly -PassThru -ErrorAction stop) )
+    if( -not (Add-Type -path $SQLiteAssembly -PassThru -ErrorAction stop) )
     {
         Throw "This module requires the ADO.NET driver for SQLite:`n`thttp://system.data.sqlite.org/index.html/doc/trunk/www/downloads.wiki"
     }
@@ -45,4 +45,4 @@
     }
     
 #Create some aliases, export public functions
-    Export-ModuleMember -Function $($Public | Select -ExpandProperty BaseName)
+    Export-ModuleMember -Function $($Public | Select-Object -ExpandProperty BaseName)


### PR DESCRIPTION
In a number of different areas where I use PSSQLite I use script analyzer before things to go production.  This was a problem because in a number of areas it would fail tests.  I've adjusted almost all of the modules\scripts in the PSSQLite module so it will pass current script analyzer default tests.  There were no major changes that would be noticeable in day-to-day use, however internally in Invoke-SqliteBulkCopy I had to rename New-SqliteBulkQuery to Invoke-SqliteBulkQuery in order to avoid having to add SupportsShouldProcess to CmdletBinding.

My previous submission failed AppVeyor tests because of how PS v2 requires SupportsShouldProcess=$true, but v3 and later does not.  I fixed that in this version as well.