### PR TITLE
changes SQLiteBulkCopy to SqliteBulkCopy to use same style as for SqliteQuery

### DIFF
--- a/PSSQLite/Invoke-SqliteBulkCopy.ps1
+++ b/PSSQLite/Invoke-SqliteBulkCopy.ps1
@@ -1,4 +1,4 @@
-﻿function Invoke-SQLiteBulkCopy {
+﻿function Invoke-SqliteBulkCopy {
 <#
 .SYNOPSIS
     Use a SQLite transaction to quickly insert data
@@ -48,7 +48,7 @@
         } | Out-DataTable
 
     #Copy the data in within a single transaction (SQLite is faster this way)
-        Invoke-SQLiteBulkCopy -DataTable $DataTable -DataSource $Database -Table Names -NotifyAfter 1000 -ConflictClause Ignore -Verbose 
+        Invoke-SqliteBulkCopy -DataTable $DataTable -DataSource $Database -Table Names -NotifyAfter 1000 -ConflictClause Ignore -Verbose 
         
 .INPUTS
     System.Data.DataTable
@@ -70,7 +70,7 @@
     New-SQLiteConnection
 
 .LINK
-    Invoke-SQLiteBulkCopy
+    Invoke-SqliteBulkCopy
 
 .LINK
     Out-DataTable
@@ -142,7 +142,7 @@
 
     )
 
-    Write-Verbose "Running Invoke-SQLiteBulkCopy with ParameterSet '$($PSCmdlet.ParameterSetName)'."
+    Write-Verbose "Running Invoke-SqliteBulkCopy with ParameterSet '$($PSCmdlet.ParameterSetName)'."
 
     Function CleanUp
     {

--- a/PSSQLite/Invoke-SqliteQuery.ps1
+++ b/PSSQLite/Invoke-SqliteQuery.ps1
@@ -153,7 +153,7 @@
         New-SQLiteConnection
 
     .LINK
-        Invoke-SQLiteBulkCopy
+        Invoke-SqliteBulkCopy
 
     .LINK
         Out-DataTable

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Insert large quantities of data quickly with transactions ([why?](http://www.sql
     } | Out-DataTable
 
 #Insert the data within a single transaction (SQLite is faster this way)
-    Invoke-SQLiteBulkCopy -DataTable $DataTable -DataSource $DataSource -Table Names -NotifyAfter 1000 -verbose
+    Invoke-SqliteBulkCopy -DataTable $DataTable -DataSource $DataSource -Table Names -NotifyAfter 1000 -verbose
 
 #View all the data!
     Invoke-SqliteQuery -DataSource $DataSource -Query "SELECT * FROM NAMES"

--- a/Tests/Invoke-SQLiteQuery.Tests.ps1
+++ b/Tests/Invoke-SQLiteQuery.Tests.ps1
@@ -121,14 +121,14 @@ Describe "Out-DataTable PS$PSVersion" {
     }
 }
 
-Describe "Invoke-SQLiteBulkCopy PS$PSVersion" {
+Describe "Invoke-SqliteBulkCopy PS$PSVersion" {
 
     Context 'Strict mode' { 
 
         Set-StrictMode -Version latest
 
         It 'should insert data' {
-            Invoke-SQLiteBulkCopy @Verbose -DataTable $Script:DataTable -DataSource $SQLiteFile -Table Names -NotifyAfter 100 -force
+            Invoke-SqliteBulkCopy @Verbose -DataTable $Script:DataTable -DataSource $SQLiteFile -Table Names -NotifyAfter 100 -force
             
             @( Invoke-SQLiteQuery @Verbose -Database $SQLiteFile -Query "SELECT fullname FROM NAMES WHERE surname = 'Name'" ).count | Should Be 1000
         }
@@ -137,21 +137,21 @@ Describe "Invoke-SQLiteBulkCopy PS$PSVersion" {
             #Basic set of tests, need more...
 
             #Try adding same data
-            { Invoke-SQLiteBulkCopy @Verbose -DataTable $Script:DataTable -DataSource $SQLiteFile -Table Names -NotifyAfter 100 -force } | Should Throw
+            { Invoke-SqliteBulkCopy @Verbose -DataTable $Script:DataTable -DataSource $SQLiteFile -Table Names -NotifyAfter 100 -force } | Should Throw
             
             #Change a known row's prop we can test to ensure it does or does not change
             $Script:DataTable.Rows[0].surname = "Name 1"
-            { Invoke-SQLiteBulkCopy @Verbose -DataTable $Script:DataTable -DataSource $SQLiteFile -Table Names -NotifyAfter 100 -force } | Should Throw
+            { Invoke-SqliteBulkCopy @Verbose -DataTable $Script:DataTable -DataSource $SQLiteFile -Table Names -NotifyAfter 100 -force } | Should Throw
 
             $Result = @( Invoke-SQLiteQuery @Verbose -Database $SQLiteFile -Query "SELECT surname FROM NAMES WHERE fullname = 'Name 1'")
             $Result[0].surname | Should Be 'Name'
 
-            { Invoke-SQLiteBulkCopy @Verbose -DataTable $Script:DataTable -DataSource $SQLiteFile -Table Names -NotifyAfter 100 -ConflictClause Rollback -Force } | Should Throw
+            { Invoke-SqliteBulkCopy @Verbose -DataTable $Script:DataTable -DataSource $SQLiteFile -Table Names -NotifyAfter 100 -ConflictClause Rollback -Force } | Should Throw
             
             $Result = @( Invoke-SQLiteQuery @Verbose -Database $SQLiteFile -Query "SELECT surname FROM NAMES WHERE fullname = 'Name 1'")
             $Result[0].surname | Should Be 'Name'
 
-            Invoke-SQLiteBulkCopy @Verbose -DataTable $Script:DataTable -DataSource $SQLiteFile -Table Names -NotifyAfter 100 -ConflictClause Replace -Force
+            Invoke-SqliteBulkCopy @Verbose -DataTable $Script:DataTable -DataSource $SQLiteFile -Table Names -NotifyAfter 100 -ConflictClause Replace -Force
 
             $Result = @( Invoke-SQLiteQuery @Verbose -Database $SQLiteFile -Query "SELECT surname FROM NAMES WHERE fullname = 'Name 1'")
             $Result[0].surname | Should Be 'Name 1'


### PR DESCRIPTION
it is a minor, but I personally think we should follow the same style for commands, not like this:

Get-Command -Module PSSQLite

CommandType     Name                                               Version    Source                                                                                                          
-----------     ----                                               -------    ------                                                                                                          
Function        Invoke-SQLiteBulkCopy                              1.0.3      PSSQLite                                                                                                        
Function        Invoke-SqliteQuery                                 1.0.3      PSSQLite                                                                                                        
Function        New-SQLiteConnection                               1.0.3      PSSQLite                                                                                                        
Function        Out-DataTable                                      1.0.3      PSSQLite                                                                                                        

So I changed Invoke-SQLiteBulkCopy to Invoke-SqliteBulkCopy
